### PR TITLE
uiの設定値を変更

### DIFF
--- a/ui.properties
+++ b/ui.properties
@@ -1,1 +1,2 @@
 server.port=${PORT:8080}
+management.security.enabled=false


### PR DESCRIPTION
config-serverの章でuiの設定値のrefreshをかける時に401になるので
`management.security.enabled=false`を追加しました。
https://github.com/Pivotal-Japan/cloud-native-workshop/blob/master/config-server.md

お手すきの時にマージしていただければと思います。